### PR TITLE
feat: Add Dependabot auto-pilot workflow

### DIFF
--- a/.github/workflows/dependabot-autopilot.yml
+++ b/.github/workflows/dependabot-autopilot.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-pilot
+
+on:
+  workflow_call:
+
+jobs:
+  dependabot:
+    name: Dependabot Auto-pilot
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We now have this successfully working elsewhere[^1]. This is a copy over the implementation from there[^2], with the job dependencies appropriately changed.

NB: Reminder that this is only for patch and minor versions, so no breaking changes will be auto-piloted in.

[^1]: https://climate-policy-radar.slack.com/archives/C078S46DJFP/p1754301566001909?thread_ts=1754300054.279629&cid=C078S46DJFP

[^2]: https://github.com/climatepolicyradar/vespa-billing-usage-tracker/blob/main/.github/workflows/cicd.yml#L61-L87
